### PR TITLE
Update damask

### DIFF
--- a/damask/bin/run_damask_3.0.0.sh
+++ b/damask/bin/run_damask_3.0.0.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mpiexec -n 1 DAMASK_grid -l tensionX.yaml -g damask.vtr
+mpiexec -n 1 DAMASK_grid -l loading.yaml -g damask.vti

--- a/damask/bin/run_damask_3.0.0_mpi.sh
+++ b/damask/bin/run_damask_3.0.0_mpi.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mpiexec -n $1 DAMASK_grid -l tensionX.yaml -g damask.vtr
+mpiexec -n $1 DAMASK_grid -l loading.yaml -g damask.vti


### PR DESCRIPTION
Updating damask script, to make it compatible with the latest development.
- The geometry file extension has changed to .vti instead of vtr
-  The name of the loading file has changed to `loading.yaml`