### PR TITLE
Add new resources for RuNNer based on the pyiron interface.

### DIFF
--- a/runner/bin/run_runner_1.2.sh
+++ b/runner/bin/run_runner_1.2.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
-RuNNer.serial.x
-sed -i 's/runner_mode 1/runner_mode 2/g' input.nn
-RuNNer.serial.x
-sed -i 's/runner_mode 2/runner_mode 3/g' input.nn
-OLD=$(ls optweights.*.out)
-TMP=${OLD/opt/}
-mv $OLD ${TMP/out/data}
+mode=$(awk '/runner_mode/{print $2}'  input.nn)
+RuNNer.serial.x | tee mode${mode}.out

--- a/runner/bin/run_runner_1.2.sh
+++ b/runner/bin/run_runner_1.2.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-MODE=$(awk '$1 == "runner_mode"{print $2}' input.nn)
+MODE=$(awk '$1 == "runner_mode"{print $2; exit}' input.nn)
 RuNNer.serial.x > mode${MODE}.out
 
 

--- a/runner/bin/run_runner_1.2.sh
+++ b/runner/bin/run_runner_1.2.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
-mode=$(awk '/runner_mode/{print $2}'  input.nn)
-RuNNer.serial.x | tee mode${mode}.out
+#!/bin/sh
+MODE=$(awk '$1 == "runner_mode"{print $2}' input.nn)
+RuNNer.serial.x > mode${MODE}.out
+
+

--- a/runner/bin/run_runner_1.2_mpi.sh
+++ b/runner/bin/run_runner_1.2_mpi.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-MODE=$(awk '$1 == "runner_mode"{print $2}' input.nn)
+MODE=$(awk '$1 == "runner_mode"{print $2; exit}' input.nn)
 mpiexec -n $1 RuNNer.serial.x | tee mode${MODE}.out

--- a/runner/bin/run_runner_1.2_mpi.sh
+++ b/runner/bin/run_runner_1.2_mpi.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
-mode=$(awk '/runner_mode/{print $2}'  input.nn)
-mpiexec -n $1 RuNNer.serial.x | tee mode${mode}.out
+#!/bin/sh
+MODE=$(awk '$1 == "runner_mode"{print $2}' input.nn)
+mpiexec -n $1 RuNNer.serial.x | tee mode${MODE}.out

--- a/runner/bin/run_runner_1.2_mpi.sh
+++ b/runner/bin/run_runner_1.2_mpi.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
-mpiexec -n $1 RuNNer.mpi.x
-sed -i 's/runner_mode 1/runner_mode 2/g' input.nn
-RuNNer.serial.x
-sed -i 's/runner_mode 2/runner_mode 3/g' input.nn
-OLD=$(ls optweights.*.out)
-TMP=${OLD/opt/}
-mv $OLD ${TMP/out/data}
+mode=$(awk '/runner_mode/{print $2}'  input.nn)
+mpiexec -n $1 RuNNer.serial.x | tee mode${mode}.out


### PR DESCRIPTION
Simplication of the resources needed to train high-dimensional neural network potentials with RuNNer.

The older version of the RuNNer resources is outdated. Because of the introduction of the `RunnerFit` job class [in pyiron_contrib](https://github.com/pyiron/pyiron_contrib/pull/315/), we no longer need to handle file renaming etc. in the bash script. 

I am currently making sure that this works correctly with the RuNNer image in conda-forge. I will check this in the ToDo list once it is done.

* [x] Assert correct behaviour with RuNNer image in conda-forge.