### PR TITLE
LAMMPS - remove oversubscribe

### DIFF
--- a/lammps/bin/run_lammps_2020.03.03_mpi.sh
+++ b/lammps/bin/run_lammps_2020.03.03_mpi.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mpiexec -n $1 --oversubscribe lmp_mpi -in control.inp;
+mpiexec -n $1 lmp_mpi -in control.inp;


### PR DESCRIPTION
This option is OpenMPI specific and does not work with MPICH.